### PR TITLE
fix crash by properly sorting input columns

### DIFF
--- a/heartmodel.py
+++ b/heartmodel.py
@@ -84,19 +84,19 @@ oldpeak = keras.Input(shape=(1,), name="oldpeak")
 slope = keras.Input(shape=(1,), name="slope")
 
 all_inputs = [
-	sex,
-	cp,
-	fbs,
-	restecg,
-	exang,
-	ca,
-	thal,
 	age,
-	trestbps,
+	ca,
 	chol,
-	thalach,
+	cp,
+	exang,
+	fbs,
 	oldpeak,
+	restecg,
+	sex,
 	slope,
+	thal,
+	thalach,
+	trestbps,
 ]
 
 # Integer categorical features


### PR DESCRIPTION
The input vector from tensorflow sorts the columns by column name, but the code creates the model inputs in a semi-arbitrary order. Sorting the model input layer columns by name fixes the casting crash that results from this. 